### PR TITLE
fix: macos compilation - including malloc.h is not required on macos …

### DIFF
--- a/txtelite.c
+++ b/txtelite.c
@@ -38,7 +38,11 @@ of Elite with no combat or missions.
 //#include <conio.h>
 //#include <graph.h>
 #include <math.h>
-#include <malloc.h>
+#ifdef _WIN32
+# ifndef __clang__
+#  include <malloc.h>
+# endif
+#endif
 
 #include <ctype.h>	// toupper / tolower
 


### PR DESCRIPTION
…and thus won't compile with clang.

Should double check that the windows macros are correct as I just winged them.